### PR TITLE
Sync iframe URL with parent via postMessage

### DIFF
--- a/site/frontend/src/graph/render.ts
+++ b/site/frontend/src/graph/render.ts
@@ -314,9 +314,12 @@ function genPlotOpts({
 
           let thisCommit = commits[dataIdx][1];
           let prevCommit = commits[dataIdx - 1][1];
-          window.open(
-            `/compare.html?start=${prevCommit}&end=${thisCommit}&stat=${stat}`
-          );
+          const params = new URLSearchParams({
+            start: prevCommit,
+            end: thisCommit,
+            stat,
+          });
+          window.location.assign(`/compare.html?${params.toString()}`);
         },
         commits,
         absoluteMode,

--- a/site/frontend/src/graph/render.ts
+++ b/site/frontend/src/graph/render.ts
@@ -319,7 +319,13 @@ function genPlotOpts({
             end: thisCommit,
             stat,
           });
-          window.location.assign(`/compare.html?${params.toString()}`);
+          // In Iframe, redirect o/w open in new tab
+          const url = `/compare.html?${params.toString()}`;
+          if (window.parent === window) {
+            window.open(url);
+          } else {
+            window.location.assign(url);
+          }
         },
         commits,
         absoluteMode,

--- a/site/frontend/src/pages/bootstrap/plots.ts
+++ b/site/frontend/src/pages/bootstrap/plots.ts
@@ -150,7 +150,11 @@ function genPlotOpts({
         onclick(_u, _seriesIdx, dataIdx) {
           let thisCommit = commits[dataIdx][1];
           let prevCommit = (commits[dataIdx - 1] || [null, null])[1];
-          window.open(`/compare.html?start=${prevCommit}&end=${thisCommit}`);
+          const params = new URLSearchParams({end: thisCommit});
+          if (prevCommit) {
+            params.set("start", prevCommit);
+          }
+          window.location.assign(`/compare.html?${params.toString()}`);
         },
         commits,
       }),

--- a/site/frontend/src/pages/bootstrap/plots.ts
+++ b/site/frontend/src/pages/bootstrap/plots.ts
@@ -154,7 +154,13 @@ function genPlotOpts({
           if (prevCommit) {
             params.set("start", prevCommit);
           }
-          window.location.assign(`/compare.html?${params.toString()}`);
+          const url = `/compare.html?${params.toString()}`;
+          // In Iframe, redirect o/w open in new tab
+          if (window.parent === window) {
+            window.open(url);
+          } else {
+            window.location.assign(url);
+          }
         },
         commits,
       }),

--- a/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
+++ b/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
@@ -19,6 +19,10 @@ const props = defineProps<{
   baseArtifact: ArtifactDescription;
 }>();
 
+const historyGraphTarget = computed(() => {
+  return window.parent === window ? "_blank" : "_self";
+});
+
 function benchmarkLink(benchmark: string): string {
   return `https://github.com/JuliaCI/BaseBenchmarks.jl/tree/master/src/${
     benchmark.split(".")[0]
@@ -62,7 +66,7 @@ function graphLink(
           <li>
             <a
               :href="graphLink(props.artifact, props.metric, props.testCase)"
-              target="_blank"
+              :target="historyGraphTarget"
             >
               History graph
             </a>

--- a/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
+++ b/site/frontend/src/pages/compare/compile/table/benchmark-detail.vue
@@ -20,6 +20,7 @@ const props = defineProps<{
 }>();
 
 const historyGraphTarget = computed(() => {
+  // Redirect if in iframe, o/w open in new tab
   return window.parent === window ? "_blank" : "_self";
 });
 

--- a/site/frontend/templates/layout.html
+++ b/site/frontend/templates/layout.html
@@ -28,5 +28,33 @@
     </div>
   </footer>
   {% block script %}{% endblock %}
+  <script>
+    // When embedded in an iframe, post URL changes to the parent so it can
+    // reflect the current view in its own address bar / deep links.
+    (function () {
+      if (window.parent === window) return;
+      function post() {
+        try {
+          window.parent.postMessage({
+            type: "julia-perf-url",
+            pathname: location.pathname,
+            search: location.search,
+            hash: location.hash,
+          }, "*");
+        } catch (e) { /* ignore */ }
+      }
+      for (const method of ["pushState", "replaceState"]) {
+        const orig = history[method];
+        history[method] = function () {
+          const ret = orig.apply(this, arguments);
+          post();
+          return ret;
+        };
+      }
+      window.addEventListener("popstate", post);
+      window.addEventListener("hashchange", post);
+      post();
+    })();
+  </script>
 </body>
 </html>

--- a/site/frontend/templates/layout.html
+++ b/site/frontend/templates/layout.html
@@ -33,15 +33,40 @@
     // reflect the current view in its own address bar / deep links.
     (function () {
       if (window.parent === window) return;
-      function post() {
+      // Only post to known parent origins. postMessage with a specific
+      // targetOrigin is a no-op if it doesn't match the parent, so it's
+      // safe to attempt all allowed origins.
+      const ALLOWED_ORIGINS = [
+        "https://juliaci.github.io",
+        "https://julialang.org",
+      ];
+      function isAllowedOrigin(origin) {
+        if (ALLOWED_ORIGINS.includes(origin)) return true;
         try {
-          window.parent.postMessage({
-            type: "julia-perf-url",
-            pathname: location.pathname,
-            search: location.search,
-            hash: location.hash,
-          }, "*");
+          const host = new URL(origin).hostname;
+          return host === "julialang.org" || host.endsWith(".julialang.org");
+        } catch (e) {
+          return false;
+        }
+      }
+      const targets = new Set(ALLOWED_ORIGINS);
+      // Also try the referrer's origin if it's a julialang.org subdomain.
+      if (document.referrer) {
+        try {
+          const refOrigin = new URL(document.referrer).origin;
+          if (isAllowedOrigin(refOrigin)) targets.add(refOrigin);
         } catch (e) { /* ignore */ }
+      }
+      function post() {
+        const msg = {
+          type: "julia-perf-url",
+          pathname: location.pathname,
+          search: location.search,
+          hash: location.hash,
+        };
+        for (const origin of targets) {
+          try { window.parent.postMessage(msg, origin); } catch (e) { /* ignore */ }
+        }
       }
       for (const method of ["pushState", "replaceState"]) {
         const orig = history[method];


### PR DESCRIPTION
When the site is embedded in an iframe (as in the JuliaCI dashboard), post the current pathname/search/hash to the parent on every history change so the parent can reflect the user's current view in its own address bar and support deep links into specific compare/graph pages.

Allows the site to be hosted on https://juliaci.github.io/julia-ci-timing/ and URLs to update as appropriate.

Written with Claude.