### PR TITLE
Open cross-origin links in a new tab when embedded

### DIFF
--- a/site/frontend/templates/layout.html
+++ b/site/frontend/templates/layout.html
@@ -96,7 +96,7 @@
         try { url = new URL(a.href, location.href); } catch (_) { return; }
         if (url.origin === location.origin) return;
         a.target = "_blank";
-        a.rel = (a.rel ? a.rel + " " : "") + "noopener noreferrer";
+        a.relList.add("noopener", "noreferrer");
       }, true);
     })();
   </script>

--- a/site/frontend/templates/layout.html
+++ b/site/frontend/templates/layout.html
@@ -80,6 +80,25 @@
       window.addEventListener("hashchange", post);
       post();
     })();
+
+    // When embedded in an iframe, open any cross-origin link in a new tab
+    // (sandboxing/CSP often prevents top-level navigation from inside the
+    // iframe, which makes such links appear broken).
+    (function () {
+      if (window.parent === window) return;
+      document.addEventListener("click", function (e) {
+        const a = e.target.closest && e.target.closest("a[href]");
+        if (!a) return;
+        if (a.target && a.target !== "" && a.target !== "_self") return;
+        const href = a.getAttribute("href");
+        if (!href || href.startsWith("#") || href.startsWith("javascript:")) return;
+        let url;
+        try { url = new URL(a.href, location.href); } catch (_) { return; }
+        if (url.origin === location.origin) return;
+        a.target = "_blank";
+        a.rel = (a.rel ? a.rel + " " : "") + "noopener noreferrer";
+      }, true);
+    })();
   </script>
 </body>
 </html>


### PR DESCRIPTION
When the site is loaded inside an iframe (as in the JuliaCI dashboard), sandbox/CSP restrictions often prevent top-level navigation, making external links such as the GitHub footer link, commit/PR references in the status page, and docs links in the compile comparison views appear broken.

Add a single capture-phase click handler in the shared layout that, only when running inside an iframe, rewrites cross-origin anchor clicks to target="_blank" with rel="noopener noreferrer". Same-origin and in-page (#hash) links are left alone.