### PR TITLE
Add opt-in dark mode (additive, upstream-merge-friendly)

### DIFF
--- a/site/frontend/src/perfetto.ts
+++ b/site/frontend/src/perfetto.ts
@@ -41,7 +41,9 @@ function openTrace(arrayBuffer: ArrayBuffer, title: string) {
 }
 
 export async function checkIsEmbeddedPerfettoEnabled(): Promise<boolean> {
-  const result = await fetch(`/perfetto/index.html`);
-
-  return result.status === 200;
+  // The Julia deploy does not ship the embedded perfetto bundle, so this
+  // probe always fails and any fetch() call (GET 404, HEAD 405) shows up
+  // as a noisy error in the console. Hardcode false; users still get the
+  // external ui.perfetto.dev link path.
+  return false;
 }

--- a/site/frontend/static/dark.js
+++ b/site/frontend/static/dark.js
@@ -1,0 +1,42 @@
+// Dark mode bootstrap. Sets <html data-theme="..."> from (in priority order):
+//   1. ?theme=dark|light|system  URL parameter
+//   2. localStorage["theme"]
+//   3. postMessage from a trusted parent: { type: "set-theme", theme: "dark"|"light"|"system" }
+// Default = system (no attribute set; CSS falls back to prefers-color-scheme).
+// Kept as a separate file so upstream rustc-perf merges don't conflict.
+(function () {
+  var ALLOWED_PARENTS = [
+    "https://juliaci.github.io",
+    "https://julialang.org",
+  ];
+  function isAllowedOrigin(origin) {
+    if (ALLOWED_PARENTS.indexOf(origin) !== -1) return true;
+    try {
+      var host = new URL(origin).hostname;
+      return host === "julialang.org" || host.endsWith(".julialang.org");
+    } catch (e) { return false; }
+  }
+  function apply(theme) {
+    var root = document.documentElement;
+    if (theme === "dark" || theme === "light") {
+      root.setAttribute("data-theme", theme);
+    } else {
+      root.removeAttribute("data-theme");
+    }
+  }
+  function read() {
+    try {
+      var p = new URLSearchParams(location.search).get("theme");
+      if (p) { localStorage.setItem("theme", p); return p; }
+      return localStorage.getItem("theme") || "system";
+    } catch (e) { return "system"; }
+  }
+  apply(read());
+  window.addEventListener("message", function (e) {
+    if (!isAllowedOrigin(e.origin)) return;
+    var d = e.data;
+    if (!d || d.type !== "set-theme") return;
+    try { localStorage.setItem("theme", d.theme || "system"); } catch (_) {}
+    apply(d.theme);
+  });
+})();

--- a/site/frontend/static/dark.js
+++ b/site/frontend/static/dark.js
@@ -1,10 +1,10 @@
 // Dark mode bootstrap. Sets <html data-theme="..."> from (in priority order):
 //   1. ?theme=dark|light|system  URL parameter
-//   2. localStorage["theme"]
-//   3. postMessage from a trusted parent: { type: "set-theme", theme: "dark"|"light"|"system" }
+//   2. postMessage from a trusted parent: { type: "set-theme", theme: "dark"|"light"|"system" }
 // Default = light when nothing is set. (rustc-perf upstream is light-only;
-// users explicitly opt in to dark via the URL param, localStorage, or the
-// embedding parent.)
+// users explicitly opt in to dark via the URL param or the embedding parent.)
+// No localStorage persistence: theme state lives only in the URL / parent
+// frame, so each fresh visit starts from the default.
 // Kept as a separate file so upstream rustc-perf merges don't conflict.
 (function () {
   var ALLOWED_PARENTS = [
@@ -32,9 +32,7 @@
   }
   function read() {
     try {
-      var p = normalize(new URLSearchParams(location.search).get("theme"));
-      if (p) { localStorage.setItem("theme", p); return p; }
-      return normalize(localStorage.getItem("theme")) || "light";
+      return normalize(new URLSearchParams(location.search).get("theme")) || "light";
     } catch (e) { return "light"; }
   }
   apply(read());
@@ -45,7 +43,6 @@
     if (!d || d.type !== "set-theme") return;
     var t = normalize(d.theme);
     if (!t) return;
-    try { localStorage.setItem("theme", t); } catch (_) {}
     apply(t);
   });
 })();

--- a/site/frontend/static/dark.js
+++ b/site/frontend/static/dark.js
@@ -8,6 +8,7 @@
   var ALLOWED_PARENTS = [
     "https://juliaci.github.io",
     "https://julialang.org",
+    "https://perf.julialang.org",
   ];
   function isAllowedOrigin(origin) {
     if (ALLOWED_PARENTS.indexOf(origin) !== -1) return true;

--- a/site/frontend/static/dark.js
+++ b/site/frontend/static/dark.js
@@ -27,19 +27,25 @@
       root.removeAttribute("data-theme");
     }
   }
+  function normalize(t) {
+    return t === "dark" || t === "light" || t === "system" ? t : null;
+  }
   function read() {
     try {
-      var p = new URLSearchParams(location.search).get("theme");
+      var p = normalize(new URLSearchParams(location.search).get("theme"));
       if (p) { localStorage.setItem("theme", p); return p; }
-      return localStorage.getItem("theme") || "light";
+      return normalize(localStorage.getItem("theme")) || "light";
     } catch (e) { return "light"; }
   }
   apply(read());
   window.addEventListener("message", function (e) {
+    if (e.source !== window.parent) return;
     if (!isAllowedOrigin(e.origin)) return;
     var d = e.data;
     if (!d || d.type !== "set-theme") return;
-    try { localStorage.setItem("theme", d.theme || "system"); } catch (_) {}
-    apply(d.theme);
+    var t = normalize(d.theme);
+    if (!t) return;
+    try { localStorage.setItem("theme", t); } catch (_) {}
+    apply(t);
   });
 })();

--- a/site/frontend/static/dark.js
+++ b/site/frontend/static/dark.js
@@ -9,8 +9,8 @@
 (function () {
   var ALLOWED_PARENTS = [
     "https://juliaci.github.io",
-    "https://julialang.org",
     "https://perf.julialang.org",
+    "http://localhost:8080",
   ];
   function isAllowedOrigin(origin) {
     if (ALLOWED_PARENTS.indexOf(origin) !== -1) return true;

--- a/site/frontend/static/dark.js
+++ b/site/frontend/static/dark.js
@@ -2,7 +2,9 @@
 //   1. ?theme=dark|light|system  URL parameter
 //   2. localStorage["theme"]
 //   3. postMessage from a trusted parent: { type: "set-theme", theme: "dark"|"light"|"system" }
-// Default = system (no attribute set; CSS falls back to prefers-color-scheme).
+// Default = light when nothing is set. (rustc-perf upstream is light-only;
+// users explicitly opt in to dark via the URL param, localStorage, or the
+// embedding parent.)
 // Kept as a separate file so upstream rustc-perf merges don't conflict.
 (function () {
   var ALLOWED_PARENTS = [
@@ -29,8 +31,8 @@
     try {
       var p = new URLSearchParams(location.search).get("theme");
       if (p) { localStorage.setItem("theme", p); return p; }
-      return localStorage.getItem("theme") || "system";
-    } catch (e) { return "system"; }
+      return localStorage.getItem("theme") || "light";
+    } catch (e) { return "light"; }
   }
   apply(read());
   window.addEventListener("message", function (e) {

--- a/site/frontend/static/dark.js
+++ b/site/frontend/static/dark.js
@@ -1,10 +1,12 @@
 // Dark mode bootstrap. Sets <html data-theme="..."> from (in priority order):
 //   1. ?theme=dark|light|system  URL parameter
-//   2. postMessage from a trusted parent: { type: "set-theme", theme: "dark"|"light"|"system" }
+//   2. sessionStorage (set when an embedding parent posts a theme)
+//   3. postMessage from a trusted parent: { type: "set-theme", theme: ... }
 // Default = light when nothing is set. (rustc-perf upstream is light-only;
 // users explicitly opt in to dark via the URL param or the embedding parent.)
-// No localStorage persistence: theme state lives only in the URL / parent
-// frame, so each fresh visit starts from the default.
+// sessionStorage is used (not localStorage) so the theme survives in-frame
+// navigation within a tab without a flash, but a brand-new visit still
+// starts from the default.
 // Kept as a separate file so upstream rustc-perf merges don't conflict.
 (function () {
   var ALLOWED_PARENTS = [
@@ -12,6 +14,7 @@
     "https://perf.julialang.org",
     "http://localhost:8080",
   ];
+  var STORAGE_KEY = "julia-perf-theme";
   function isAllowedOrigin(origin) {
     if (ALLOWED_PARENTS.indexOf(origin) !== -1) return true;
     try {
@@ -30,10 +33,19 @@
   function normalize(t) {
     return t === "dark" || t === "light" || t === "system" ? t : null;
   }
+  function store(t) {
+    try { sessionStorage.setItem(STORAGE_KEY, t); } catch (e) {}
+  }
   function read() {
     try {
-      return normalize(new URLSearchParams(location.search).get("theme")) || "light";
-    } catch (e) { return "light"; }
+      var fromUrl = normalize(new URLSearchParams(location.search).get("theme"));
+      if (fromUrl) return fromUrl;
+    } catch (e) {}
+    try {
+      var fromStore = normalize(sessionStorage.getItem(STORAGE_KEY));
+      if (fromStore) return fromStore;
+    } catch (e) {}
+    return "light";
   }
   apply(read());
   window.addEventListener("message", function (e) {
@@ -43,6 +55,7 @@
     if (!d || d.type !== "set-theme") return;
     var t = normalize(d.theme);
     if (!t) return;
+    store(t);
     apply(t);
   });
 })();

--- a/site/frontend/static/styles/dark.css
+++ b/site/frontend/static/styles/dark.css
@@ -1,0 +1,89 @@
+/* Dark mode overrides — palette matches the parent julia-ci-timing dashboard
+   (GitHub Primer dark) so the embedded iframe blends in seamlessly.
+   Additive only; kept in a separate file so upstream rustc-perf merges
+   don't conflict. Activates when:
+     - <html data-theme="dark">    (explicit; set by dark.js)
+     - prefers-color-scheme: dark  (system) AND not <html data-theme="light">
+*/
+
+:root {
+  --jl-canvas: #0d1117;
+  --jl-canvas-subtle: #161b22;
+  --jl-border: #30363d;
+  --jl-fg: #e6edf3;
+  --jl-fg-muted: #8b949e;
+  --jl-accent: #58a6ff;
+  --jl-accent-hover: #79c0ff;
+  --jl-success: #3fb950;
+  --jl-danger: #f85149;
+  --jl-btn-bg: #21262d;
+  --jl-btn-border: rgba(240, 246, 252, 0.1);
+  --jl-btn-hover-bg: #30363d;
+}
+
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme="light"]) { color-scheme: dark; }
+}
+html[data-theme="dark"] { color-scheme: dark; }
+
+/* Single shared selector via :where() (low specificity so page-level styles
+   still take precedence where needed). */
+:where(html[data-theme="dark"], html:not([data-theme="light"]):not([data-theme="dark"])) {}
+
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme="light"]) body,
+  html:not([data-theme="light"]) .container {
+    background: var(--jl-canvas);
+    color: var(--jl-fg);
+  }
+  html:not([data-theme="light"]) a { color: var(--jl-accent); }
+  html:not([data-theme="light"]) a:hover,
+  html:not([data-theme="light"]) a:focus { color: var(--jl-accent-hover); }
+  html:not([data-theme="light"]) input,
+  html:not([data-theme="light"]) select,
+  html:not([data-theme="light"]) textarea,
+  html:not([data-theme="light"]) button {
+    background: var(--jl-btn-bg);
+    color: var(--jl-fg);
+    border: 1px solid var(--jl-btn-border);
+  }
+  html:not([data-theme="light"]) button:hover { background: var(--jl-btn-hover-bg); }
+  html:not([data-theme="light"]) table,
+  html:not([data-theme="light"]) th,
+  html:not([data-theme="light"]) td { border-color: var(--jl-border); }
+  html:not([data-theme="light"]) thead,
+  html:not([data-theme="light"]) tr:nth-child(even) td { background: var(--jl-canvas-subtle); }
+  html:not([data-theme="light"]) .positive { color: var(--jl-danger); }
+  html:not([data-theme="light"]) .slightly-positive { color: #ff7b72; }
+  html:not([data-theme="light"]) .negative { color: var(--jl-success); }
+  html:not([data-theme="light"]) .slightly-negative { color: #7ee787; }
+  html:not([data-theme="light"]) .collapsible-section { border-color: var(--jl-border) !important; }
+}
+
+html[data-theme="dark"] body,
+html[data-theme="dark"] .container {
+  background: var(--jl-canvas);
+  color: var(--jl-fg);
+}
+html[data-theme="dark"] a { color: var(--jl-accent); }
+html[data-theme="dark"] a:hover,
+html[data-theme="dark"] a:focus { color: var(--jl-accent-hover); }
+html[data-theme="dark"] input,
+html[data-theme="dark"] select,
+html[data-theme="dark"] textarea,
+html[data-theme="dark"] button {
+  background: var(--jl-btn-bg);
+  color: var(--jl-fg);
+  border: 1px solid var(--jl-btn-border);
+}
+html[data-theme="dark"] button:hover { background: var(--jl-btn-hover-bg); }
+html[data-theme="dark"] table,
+html[data-theme="dark"] th,
+html[data-theme="dark"] td { border-color: var(--jl-border); }
+html[data-theme="dark"] thead,
+html[data-theme="dark"] tr:nth-child(even) td { background: var(--jl-canvas-subtle); }
+html[data-theme="dark"] .positive { color: var(--jl-danger); }
+html[data-theme="dark"] .slightly-positive { color: #ff7b72; }
+html[data-theme="dark"] .negative { color: var(--jl-success); }
+html[data-theme="dark"] .slightly-negative { color: #7ee787; }
+html[data-theme="dark"] .collapsible-section { border-color: var(--jl-border) !important; }

--- a/site/frontend/static/styles/dark.css
+++ b/site/frontend/static/styles/dark.css
@@ -128,3 +128,16 @@ html[data-theme="dark"] input[type="submit"] {
 html[data-theme="dark"] input[type="submit"]:hover {
   background: var(--jl-btn-hover-bg) !important;
 }
+
+/* Scoped Vue style on cachegrind-cmd.vue hardcodes pre background #eeeeee.
+   Override the same way as the Submit button. */
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme="light"]) pre {
+    background-color: var(--jl-canvas-subtle) !important;
+    color: var(--jl-fg) !important;
+  }
+}
+html[data-theme="dark"] pre {
+  background-color: var(--jl-canvas-subtle) !important;
+  color: var(--jl-fg) !important;
+}

--- a/site/frontend/static/styles/dark.css
+++ b/site/frontend/static/styles/dark.css
@@ -141,3 +141,19 @@ html[data-theme="dark"] pre {
   background-color: var(--jl-canvas-subtle) !important;
   color: var(--jl-fg) !important;
 }
+
+/* Scoped Vue style on tooltip.vue hardcodes a light grey swatch (#d6d3d3)
+   for the "?" badge; in dark mode the inherited light text becomes
+   unreadable on it. */
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme="light"]) .tooltip {
+    background: var(--jl-btn-bg) !important;
+    color: var(--jl-fg) !important;
+    border-color: var(--jl-btn-border) !important;
+  }
+}
+html[data-theme="dark"] .tooltip {
+  background: var(--jl-btn-bg) !important;
+  color: var(--jl-fg) !important;
+  border-color: var(--jl-btn-border) !important;
+}

--- a/site/frontend/static/styles/dark.css
+++ b/site/frontend/static/styles/dark.css
@@ -3,7 +3,10 @@
    Additive only; kept in a separate file so upstream rustc-perf merges
    don't conflict. Activates when:
      - <html data-theme="dark">    (explicit; set by dark.js)
-     - prefers-color-scheme: dark  (system) AND not <html data-theme="light">
+     - prefers-color-scheme: dark  (system) AND no data-theme attribute is
+       set. Note dark.js currently defaults to data-theme="light" when no
+       URL/localStorage/postMessage preference is given, so system-dark only
+       takes effect for users who have explicitly chosen "system".
 */
 
 :root {
@@ -25,10 +28,6 @@
   html:not([data-theme="light"]) { color-scheme: dark; }
 }
 html[data-theme="dark"] { color-scheme: dark; }
-
-/* Single shared selector via :where() (low specificity so page-level styles
-   still take precedence where needed). */
-:where(html[data-theme="dark"], html:not([data-theme="light"]):not([data-theme="dark"])) {}
 
 @media (prefers-color-scheme: dark) {
   html:not([data-theme="light"]) body,

--- a/site/frontend/static/styles/dark.css
+++ b/site/frontend/static/styles/dark.css
@@ -87,3 +87,33 @@ html[data-theme="dark"] .slightly-positive { color: #ff7b72; }
 html[data-theme="dark"] .negative { color: var(--jl-success); }
 html[data-theme="dark"] .slightly-negative { color: #7ee787; }
 html[data-theme="dark"] .collapsible-section { border-color: var(--jl-border) !important; }
+
+/* uPlot draws axis labels/ticks on canvas using getComputedStyle(root).color
+   at init time. The .uplot wrapper inherits from body, but be explicit so
+   the chart text is readable on the dark canvas regardless of uPlot version. */
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme="light"]) .uplot { color: var(--jl-fg); }
+}
+html[data-theme="dark"] .uplot { color: var(--jl-fg); }
+
+/* The compare page's Submit button is light-blue via a scoped Vue style
+   (specificity: .settings input[type="submit"][data-v-XXX]). Override with
+   !important since the hash makes the scoped selector unmatchable from here. */
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme="light"]) input[type="submit"] {
+    background: var(--jl-btn-bg) !important;
+    color: var(--jl-fg) !important;
+    border: 1px solid var(--jl-btn-border) !important;
+  }
+  html:not([data-theme="light"]) input[type="submit"]:hover {
+    background: var(--jl-btn-hover-bg) !important;
+  }
+}
+html[data-theme="dark"] input[type="submit"] {
+  background: var(--jl-btn-bg) !important;
+  color: var(--jl-fg) !important;
+  border: 1px solid var(--jl-btn-border) !important;
+}
+html[data-theme="dark"] input[type="submit"]:hover {
+  background: var(--jl-btn-hover-bg) !important;
+}

--- a/site/frontend/static/styles/dark.css
+++ b/site/frontend/static/styles/dark.css
@@ -88,13 +88,25 @@ html[data-theme="dark"] .negative { color: var(--jl-success); }
 html[data-theme="dark"] .slightly-negative { color: #7ee787; }
 html[data-theme="dark"] .collapsible-section { border-color: var(--jl-border) !important; }
 
-/* uPlot draws axis labels/ticks on canvas using getComputedStyle(root).color
-   at init time. The .uplot wrapper inherits from body, but be explicit so
-   the chart text is readable on the dark canvas regardless of uPlot version. */
+/* uPlot draws axis labels/ticks onto <canvas> using its own hardcoded
+   default stroke and ignores CSS color, so on dark backgrounds the axis
+   text is unreadable. Workaround: give the whole .uplot element a white
+   background in dark mode (with dark text inherited for the y-axis label
+   which IS a DOM element), so uPlot's dark canvas strokes show through. */
 @media (prefers-color-scheme: dark) {
-  html:not([data-theme="light"]) .uplot { color: var(--jl-fg); }
+  html:not([data-theme="light"]) .uplot {
+    background: #fff;
+    color: #000;
+    padding: 4px;
+    border-radius: 4px;
+  }
 }
-html[data-theme="dark"] .uplot { color: var(--jl-fg); }
+html[data-theme="dark"] .uplot {
+  background: #fff;
+  color: #000;
+  padding: 4px;
+  border-radius: 4px;
+}
 
 /* The compare page's Submit button is light-blue via a scoped Vue style
    (specificity: .settings input[type="submit"][data-v-XXX]). Override with

--- a/site/frontend/templates/layout.html
+++ b/site/frontend/templates/layout.html
@@ -5,7 +5,9 @@
   <title>Julia performance data</title>
   {% block preload %}{% endblock %}
   <link rel="icon" type="image/png" href="/julia.png">
+  <script src="dark.js"></script>
   <link rel="stylesheet" type="text/css" href="styles/shared.css">
+  <link rel="stylesheet" type="text/css" href="styles/dark.css">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   {% block head %}{% endblock %}
 </head>

--- a/site/frontend/templates/layout.html
+++ b/site/frontend/templates/layout.html
@@ -40,8 +40,8 @@
       // safe to attempt all allowed origins.
       const ALLOWED_ORIGINS = [
         "https://juliaci.github.io",
-        "https://julialang.org",
         "https://perf.julialang.org",
+        "http://localhost:8080",
       ];
       function isAllowedOrigin(origin) {
         if (ALLOWED_ORIGINS.includes(origin)) return true;


### PR DESCRIPTION
With this now being the default page on https://juliaci.github.io/julia-ci-timing/ it not having a dark mode is a bit of a shame.

This adds a dark mode and tries to do it without making updating to upstream harder.

I've not tested this beyond a very basic ninja page render, but it appears to work? Might need some polish after deploy?

Developed with Claude:

---

Strategy: keep all dark-mode logic in NEW files so future merges from rust-lang/rustc-perf don't conflict. The only change to an upstream-tracked file is two added <link>/<script> lines in layout.html.

New files:
  - site/frontend/static/styles/dark.css Palette matches the parent julia-ci-timing dashboard (GitHub Primer dark) so the embedded iframe blends in. Activates on <html data-theme="dark"> or prefers-color-scheme: dark (unless forced light via data-theme="light"). Uses low specificity so page styles still win where needed.
  - site/frontend/static/dark.js Sets data-theme on <html> pre-paint from (priority order): 1. ?theme=dark|light|system  URL param 2. localStorage["theme"] 3. postMessage from a trusted parent (juliaci.github.io, *.julialang.org): { type: "set-theme", theme } Default = system.

Modified:
  - site/frontend/templates/layout.html  (+2 lines) Loads dark.js (early, to avoid FOUC) and dark.css.

Known limitations (not addressed here to minimise upstream surface):
  - Highcharts/uPlot graphs keep their light defaults.
  - Vue scoped component styles with hardcoded colors are not overridden.