### PR TITLE
Add perf.julialang.org to iframe URL-sync allow-list

### DIFF
--- a/site/frontend/templates/layout.html
+++ b/site/frontend/templates/layout.html
@@ -39,6 +39,7 @@
       const ALLOWED_ORIGINS = [
         "https://juliaci.github.io",
         "https://julialang.org",
+        "https://perf.julialang.org",
       ];
       function isAllowedOrigin(origin) {
         if (ALLOWED_ORIGINS.includes(origin)) return true;


### PR DESCRIPTION
The dashboard was moved to https://perf.julialang.org/ and now embeds this site. URL sync (julia-perf-url postMessage -> parent) was silently broken because the parent's referrerpolicy='no-referrer' prevented isAllowedOrigin() from picking the subdomain up via document.referrer, and the static ALLOWED_ORIGINS only listed the bare julialang.org and juliaci.github.io. Add the actual subdomain explicitly so URL sync works without depending on referrer.